### PR TITLE
fix concurrent and default source

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-module.exports = function() {
-  var userAgent = new require('./lib/useragent').UserAgent();
+var UserAgent = require('./lib/useragent').UserAgent;
 
+module.exports = function() {
   return function *(next) {
     var source =  this.request.headers['user-agent'] || '';
-    var ua = userAgent;
-
-    ua.reset();
+    var ua = new UserAgent();
 
     if (typeof source === 'undefined') {
         source = 'unknown';

--- a/index.js
+++ b/index.js
@@ -2,12 +2,8 @@ var UserAgent = require('./lib/useragent').UserAgent;
 
 module.exports = function() {
   return function *(next) {
-    var source =  this.request.headers['user-agent'] || '';
+    var source =  this.request.headers['user-agent'] || 'unknown';
     var ua = new UserAgent();
-
-    if (typeof source === 'undefined') {
-        source = 'unknown';
-    }
 
     ua.Agent.source = source.replace(/^\s*/, '').replace(/\s*$/, '');
     ua.Agent.os = ua.getOS(ua.Agent.source);


### PR DESCRIPTION
It is a serious problem that each request shares the same UserAgent instance. #6, #7 are victims. #9 tries to fix it but does not solve the root cause.

Supoose we used 2 koa middlewares: koa-useragent and read-useragent. Then: 1)a iPhone request makes `useAgent.Agent.isiPhone` to be `true` and yield. 2)another not-iPhone request makes it be `false` and yield. 3)the first request enters read-useragent middleware and gets the wrong user agent!

```
request1:   1)koa-useragent                 3)read-useragent(wrong ua!)
request2:                 2)koa-useragent                         4)read-useragent
```

Btw, if `source` is empty, it will be set as an empty string. So the undefined check is useless.