### PR TITLE
Avoid mis-detection of Chrome Android 8.0 as Opera

### DIFF
--- a/lib/useragent.js
+++ b/lib/useragent.js
@@ -126,7 +126,8 @@ class UserAgent {
       Chrome: /chrome/i,
       Safari: /safari/i,
       IE: /msie|trident/i,
-      Opera: /opera|OPR/i,
+      // don't match " Build/OPRxxxx " which indicates Chrome on Android 8+
+      Opera: /opera|\sOPR/i,
       PS3: /playstation 3/i,
       PSP: /playstation portable/i,
       Firefox: /firefox/i,

--- a/test/browsers.js
+++ b/test/browsers.js
@@ -564,6 +564,34 @@ test('OS X Chromium', (t) => {
   t.true(!a.isIECompatibilityMode);
 });
 
+// Source: copied from an OnePlus phone
+test('Android 8.0 Chrome', (t) => {
+  const s = 'Mozilla/5.0 (Linux; Android 8.0.0; ONEPLUS A3003 Build/OPR6.170623.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36';
+
+  const a = new UserAgent(s);
+
+  t.true(a.isAuthoritative, 'Authoritative');
+  t.true(a.isMobile, 'Mobile');
+  t.true(!a.isiPad, 'iPad');
+  t.true(!a.isiPod, 'iPod');
+  t.true(!a.isiPhone, 'iPhone');
+  t.true(a.isAndroid, 'Android');
+  t.true(!a.isBlackberry, 'Blackberry');
+  t.true(!a.isOpera, 'Opera');
+  t.true(!a.isIE, 'IE');
+  t.true(!a.isSafari, 'Safari');
+  t.true(!a.isFirefox, 'Firefox');
+  t.true(!a.isWebkit, 'Webkit');
+  t.true(a.isChrome, 'Chrome');
+  t.true(!a.isKonqueror, 'Konqueror');
+  t.true(!a.isDesktop, 'Desktop');
+  t.true(!a.isWindows, 'Windows');
+  t.true(a.isLinux, 'Linux');
+  t.true(!a.isMac, 'Mac');
+  t.true(!a.isWindowsPhone, 'Windows Phone');
+  t.is(a.version, '64.0.3282.137');
+});
+
 // Source:
 // http://www.gtrifonov.com/2011/04/15/google-android-user-agent-strings-2/
 test('Android Samsung', (t) => {


### PR DESCRIPTION
Improve the Opera regex to only match white space + OPR, because Chrome
on Android 8 includes the string "...Build/OPRxxxx".

Add a new test using a UserAgent string copied from an OnePlus phone.

Fixes #13