### PR TITLE
add support for Electron

### DIFF
--- a/lib/useragent.js
+++ b/lib/useragent.js
@@ -24,6 +24,7 @@ class UserAgent {
     this.testSilk();
     this.testKindleFire();
     this.testCaptiveNetwork();
+    this.testElectron();
 
     return this.agent;
   }
@@ -89,6 +90,10 @@ class UserAgent {
 
   static get isBotRegExp() {
     return new RegExp(`^.*(${UserAgent.bots.join('|')}).*$`);
+  }
+
+  static get isElectronRegExp() {
+    return /Electron\/([\d\w\.\-]+)/i;
   }
 
   static get versions() {
@@ -238,12 +243,14 @@ class UserAgent {
       isCaptive: false,
       isSmartTV: false,
       isUC: false,
+      isElectron: false,
       silkAccelerated: false,
       browser: 'unknown',
       version: 'unknown',
       os: 'unknown',
       platform: 'unknown',
       geoIp: {},
+      electronVersion: '',
       source: '',
     };
   }
@@ -736,6 +743,14 @@ class UserAgent {
   testAndroidTablet() {
     if (this.agent.isAndroid && !/mobile/i.test(this.agent.source)) {
       this.agent.isAndroidTablet = true;
+    }
+  }
+
+  testElectron() {
+    if (UserAgent.isElectronRegExp.test(this.agent.source.toLowerCase())) {
+      this.agent.isElectron = true;
+      this.agent.electronVersion = RegExp.$1;
+      this.agent.isDesktop = true;
     }
   }
 }

--- a/test/browsers.js
+++ b/test/browsers.js
@@ -1106,3 +1106,32 @@ test('PhantomJS', (t) => {
   t.is(a.version, '1.9.8');
   t.true(!a.isIECompatibilityMode);
 });
+
+test('OS X Electron', (t) => {
+  const s = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) electron-app-name/1.0.0 Chrome/59.0.3071.115 Electron/1.8.3 Safari/537.36';
+
+  const a = new UserAgent(s);
+
+  t.true(a.isAuthoritative, 'Authoritative');
+  t.true(!a.isMobile, 'Mobile');
+  t.true(!a.isiPad, 'iPad');
+  t.true(!a.isiPod, 'iPod');
+  t.true(!a.isiPhone, 'iPhone');
+  t.true(!a.isAndroid, 'Android');
+  t.true(!a.isBlackberry, 'Blackberry');
+  t.true(!a.isOpera, 'Opera');
+  t.true(!a.isIE, 'IE');
+  t.true(!a.isSafari, 'Safari');
+  t.true(!a.isFirefox, 'Firefox');
+  t.true(!a.isWebkit, 'Webkit');
+  t.true(a.isChrome, 'Chrome');
+  t.true(!a.isKonqueror, 'Konqueror');
+  t.true(a.isDesktop, 'Desktop');
+  t.true(!a.isWindows, 'Windows');
+  t.true(!a.isLinux, 'Linux');
+  t.true(a.isMac, 'Mac');
+  t.true(!a.isWindowsPhone, 'Windows Phone');
+  t.is(a.version, '59.0.3071.115');
+  t.true(!a.isIECompatibilityMode);
+  t.is(a.electronVersion, '1.8.3');
+});


### PR DESCRIPTION
I'm using this library on our backend and I noticed it does not detect Electron yet.

Note that this will only work for http requests coming from renderer processes. To make this work for http requests coming from the main (Node.js) process, you'll have to manually add the `user-agent` header to your requests, for example by copying it from one of the renderer processes like this: `myBrowserWindow.webContents.session.getUserAgent()`